### PR TITLE
HardwareSerial: add interrupt driven reception

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -54,6 +54,12 @@ void HardwareSerial::init(PinName _rx, PinName _tx, PinName _rts, PinName _cts)
   _serial.pin_tx = _tx;
   _serial.pin_rts = _rts;
   _serial.pin_cts = _cts;
+
+  _serial.rx_callback = NULL;
+  _serial.rx_buff = _rx_buffer;
+  _serial.rx_size = SERIAL_RX_BUFFER_SIZE;
+  _serial.rx_head = 0;
+  _serial.rx_tail = 0;
 }
 
 
@@ -138,32 +144,54 @@ void HardwareSerial::begin(unsigned long baud, byte config)
       break;
   }
   uart_init(&_serial, (uint32_t)baud, databits, parity, stopbits);
+
+  _serial.rx_head = 0;
+  _serial.rx_tail = 0;
+  uart_attach_rx_callback(&_serial, _rx_complete_irq);
 }
 
 void HardwareSerial::end()
 {
   uart_deinit(&_serial);
+
+  _serial.rx_head = 0;
+  _serial.rx_tail = 0;
+}
+
+// Called from the RXNE interrupt: store the received byte, drop it when the
+// ring buffer is full so the oldest data is kept.
+void HardwareSerial::_rx_complete_irq(serial_t *obj)
+{
+  rx_buffer_index_t i = (rx_buffer_index_t)((obj->rx_head + 1) % SERIAL_RX_BUFFER_SIZE);
+
+  if (i != obj->rx_tail) {
+    obj->rx_buff[obj->rx_head] = obj->recv;
+    obj->rx_head = i;
+  }
 }
 
 int HardwareSerial::available(void)
 {
-  return -1;
+  return ((unsigned int)(SERIAL_RX_BUFFER_SIZE + _serial.rx_head - _serial.rx_tail)) % SERIAL_RX_BUFFER_SIZE;
 }
 
 int HardwareSerial::peek(void)
 {
-   return -1;
+  if (_serial.rx_head == _serial.rx_tail) {
+    return -1;
+  }
+  return _rx_buffer[_serial.rx_tail];
 }
 
 int HardwareSerial::read(void)
 {
-
-  unsigned char c;
-  if(uart_getc(&_serial, &c) == 0){
-    return c;
-  }else{
+  if (_serial.rx_head == _serial.rx_tail) {
     return -1;
   }
+
+  unsigned char c = _rx_buffer[_serial.rx_tail];
+  _serial.rx_tail = (rx_buffer_index_t)((_serial.rx_tail + 1) % SERIAL_RX_BUFFER_SIZE);
+  return c;
 }
 
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -155,9 +155,13 @@ public:
     void setCts(PinName _cts);
     void setRtsCts(PinName _rts, PinName _cts);
     void setHandler(void *handler);
+
+    // Called from the uart RXNE interrupt to push a byte into _rx_buffer
+    static void _rx_complete_irq(serial_t *obj);
   private:
     uint8_t _config;
     unsigned long _baud;
+    unsigned char _rx_buffer[SERIAL_RX_BUFFER_SIZE];
     void init(PinName _rx, PinName _tx, PinName _rts = NC, PinName _cts = NC);
 };
 

--- a/cores/arduino/ch32/uart.c
+++ b/cores/arduino/ch32/uart.c
@@ -293,6 +293,8 @@ void uart_init(serial_t *obj, uint32_t baudrate, uint32_t databits, uint32_t par
   */
 void uart_deinit(serial_t *obj)
 {
+  uart_detach_rx_callback(obj);
+
   /* Reset UART and disable clock */
   switch (obj->index) 
   {
@@ -527,6 +529,142 @@ int uart_getc(serial_t *obj, unsigned char *c)
 
   return 0;
 }
+
+/**
+  * @brief  Enable the RXNE interrupt and register the reception callback
+  * @param  obj : pointer to serial_t structure
+  * @param  callback : function called from the ISR once a byte is received
+  * @retval None
+  */
+void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *))
+{
+  if ((obj == NULL) || (callback == NULL) || (obj->index >= UART_NUM)) {
+    return;
+  }
+  /* Half-duplex or Tx only: there is nothing to receive */
+  if (obj->pin_rx == NC) {
+    return;
+  }
+
+  obj->rx_callback = callback;
+
+  /* Drop whatever was received before the interrupt is enabled, this also
+     clears a pending RXNE/ORE so the ISR is not entered with a stale byte */
+  (void)USART_ReceiveData(obj->handle.Instance);
+
+  NVIC_SetPriority(obj->irq, UART_IRQ_PRIO);
+  NVIC_EnableIRQ(obj->irq);
+  USART_ITConfig(obj->handle.Instance, USART_IT_RXNE, ENABLE);
+}
+
+/**
+  * @brief  Disable the RXNE interrupt
+  * @param  obj : pointer to serial_t structure
+  * @retval None
+  */
+void uart_detach_rx_callback(serial_t *obj)
+{
+  if ((obj == NULL) || (obj->index >= UART_NUM)) {
+    return;
+  }
+
+  USART_ITConfig(obj->handle.Instance, USART_IT_RXNE, DISABLE);
+  NVIC_DisableIRQ(obj->irq);
+  obj->rx_callback = NULL;
+}
+
+/**
+  * @brief  Common RXNE interrupt handler
+  * @param  index : uart instance the interrupt comes from
+  * @retval None
+  */
+static void uart_rx_irq(uart_index_t index)
+{
+  UART_HandleTypeDef *huart = uart_handlers[index];
+
+  if (huart == NULL) {
+    return;
+  }
+
+  /* RXNE and ORE are both cleared by reading STATR then DATAR, so the byte is
+     still delivered when an overrun happened while interrupts were masked */
+  if ((USART_GetFlagStatus(huart->Instance, USART_FLAG_RXNE) != RESET)
+      || (USART_GetFlagStatus(huart->Instance, USART_FLAG_ORE) != RESET)) {
+    uint8_t data = (uint8_t)(USART_ReceiveData(huart->Instance) & 0xFF);
+    serial_t *obj = get_serial_obj(huart);
+
+    if ((obj != NULL) && (obj->rx_callback != NULL)) {
+      obj->recv = data;
+      obj->rx_callback(obj);
+    }
+  }
+}
+
+/* The handlers are only built when a HardwareSerial instance can exist, so a
+   sketch driving a U(S)ART on its own (without SERIAL_UART_INSTANCE) keeps
+   full control of the vector. They must be strong definitions: the startup
+   code already provides weak stubs that spin forever, and between two weak
+   definitions the linker keeps the startup one.
+
+   Plain interrupt attribute (machine mode) on purpose: some RISC-V toolchains
+   used to build this core reject the WCH specific
+   interrupt("WCH-Interrupt-fast") argument and then drop the attribute
+   altogether, which leaves the handler returning with ret instead of mret.
+   The interrupt is then delivered exactly once and never again. */
+#if defined(SERIAL_UART_INSTANCE)
+
+#define UART_IRQ_HANDLER __attribute__((interrupt)) void
+
+#if defined(USART1_BASE)
+UART_IRQ_HANDLER USART1_IRQHandler(void)
+{
+  uart_rx_irq(UART1_INDEX);
+}
+#endif
+#if defined(USART2_BASE)
+UART_IRQ_HANDLER USART2_IRQHandler(void)
+{
+  uart_rx_irq(UART2_INDEX);
+}
+#endif
+#if defined(USART3_BASE)
+UART_IRQ_HANDLER USART3_IRQHandler(void)
+{
+  uart_rx_irq(UART3_INDEX);
+}
+#endif
+#if defined(UART4_BASE)
+UART_IRQ_HANDLER UART4_IRQHandler(void)
+{
+  uart_rx_irq(UART4_INDEX);
+}
+#endif
+#if defined(UART5_BASE)
+UART_IRQ_HANDLER UART5_IRQHandler(void)
+{
+  uart_rx_irq(UART5_INDEX);
+}
+#endif
+#if defined(UART6_BASE)
+UART_IRQ_HANDLER UART6_IRQHandler(void)
+{
+  uart_rx_irq(UART6_INDEX);
+}
+#endif
+#if defined(UART7_BASE)
+UART_IRQ_HANDLER UART7_IRQHandler(void)
+{
+  uart_rx_irq(UART7_INDEX);
+}
+#endif
+#if defined(UART8_BASE)
+UART_IRQ_HANDLER UART8_IRQHandler(void)
+{
+  uart_rx_irq(UART8_INDEX);
+}
+#endif
+
+#endif /* SERIAL_UART_INSTANCE */
 
 
 

--- a/cores/arduino/ch32/uart.h
+++ b/cores/arduino/ch32/uart.h
@@ -66,16 +66,24 @@ typedef struct __UART_HandleTypeDef
 
 
   typedef struct serial_s serial_t;
-  struct serial_s 
+  struct serial_s
   {
-    USART_TypeDef       *uart;  
-    UART_HandleTypeDef   handle;   
+    USART_TypeDef       *uart;
+    UART_HandleTypeDef   handle;
     PinName pin_tx;
     PinName pin_rx;
     PinName pin_rts;
     PinName pin_cts;
     IRQn_Type irq;
     uint8_t index;
+    /* Interrupt driven reception. The ring buffer itself is owned by the
+       caller (HardwareSerial), uart.c only fills it from the RXNE ISR. */
+    void (*rx_callback)(serial_t *);
+    uint8_t  *rx_buff;
+    uint16_t  rx_size;
+    volatile uint16_t rx_head;
+    volatile uint16_t rx_tail;
+    uint8_t  recv;
   };
 
 
@@ -90,6 +98,9 @@ typedef struct __UART_HandleTypeDef
   void uart_deinit(serial_t *obj);
 
   int uart_getc(serial_t *obj, unsigned char *c);
+
+  void uart_attach_rx_callback(serial_t *obj, void (*callback)(serial_t *));
+  void uart_detach_rx_callback(serial_t *obj);
 
   uint8_t serial_tx_active(serial_t *obj);
   uint8_t serial_rx_active(serial_t *obj);


### PR DESCRIPTION
## Summary

`HardwareSerial::available()` always returned `-1`, and so did `peek()`.

Because of that, `if (Serial.available())` is always true, and the Stream API (`parseInt()`, `readStringUntil()`, ...) does not work. There is no way to tell whether data has arrived, so reception through `Serial` is effectively unusable.

This adds a USART RXNE interrupt and a ring buffer (64 bytes by default) so that `available()` returns the number of buffered bytes. `peek()` and `read()` now read from that buffer.

## How to reproduce

```cpp
void setup() { Serial.begin(115200); }
void loop() {
  if (Serial.available()) {   // always true
    int c = Serial.read();    // -1 when nothing was received
  }
}
```

Before this change `available()` keeps returning `-1`, which is true, so the block is entered even when nothing has been received.

## What changed

| File | Change |
|---|---|
| `cores/arduino/ch32/uart.h` | Add the reception callback and the ring buffer members to `serial_t` |
| `cores/arduino/ch32/uart.c` | Add `uart_attach_rx_callback()` / `uart_detach_rx_callback()` and the RXNE interrupt handlers |
| `cores/arduino/HardwareSerial.cpp` | `available()` / `peek()` / `read()` now go through the ring buffer |
| `cores/arduino/HardwareSerial.h` | Add the ring buffer and the callback called from the ISR |

Two design notes.

**The interrupt handlers are only built when `SERIAL_UART_INSTANCE` is defined.** This way a sketch that drives a U(S)ART on its own keeps full control of the vector.

**The plain `interrupt` attribute (machine mode) is used on purpose.** Some RISC-V toolchains reject the WCH specific `interrupt("WCH-Interrupt-fast")` argument and then **drop the attribute altogether**. The handler is then compiled as an ordinary function and returns with `ret` instead of `mret`, so that IRQ is delivered exactly once and never again. The CPU keeps running, which makes it look like "only the first byte is received and then nothing happens".

## Cost

Measured on CH32V003 (16 KB flash / 2 KB RAM) by building the same sketch against stock 1.0.42 and against this PR.

```cpp
void setup() { Serial.begin(115200); }
void loop()  { if (Serial.available()) Serial.write(Serial.read()); }
```

| | Flash | RAM |
|---|---|---|
| stock 1.0.42 | 5224 B | 512 B |
| with this PR | 5568 B | 608 B |
| **difference** | **+344 B** | **+96 B** |

Most of the RAM increase is the ring buffer. It can be changed by defining `SERIAL_RX_BUFFER_SIZE` (64 bytes by default).

## Verification

**Setup**

- Board: Pro Micro CH32V003, Board Version V1.4
- Core: `UIAP:ch32v` 1.0.42 with only the changes of this PR applied
- Options: 48MHz Internal / Smallest (-Os) / Newlib Nano
- Toolchain: `riscv-none-embed-gcc` 8.2.0

**Method**

No USB serial adapter was used. PD5 (TX) and PD6 (RX) were wired together as a loopback. The UART is busy with the loopback, so the result is reported on the LED.

**Results**

- `available()` returns the number of buffered bytes
- no byte is lost while the sketch is busy and never calls `read()` in between, so they can only have survived through the interrupt
- `peek()` returns the first byte, and `peek() == read()`
- after everything has been read, `available() == 0` and `read() == -1`
- `end()` -> `begin()` restarts reception
- a 26 byte string compared byte by byte keeps matching round after round in `loop()`, not just once
- the build is warning free with `--warnings all`
- the generated `USART1_IRQHandler` ends with `mret` (checked with `objdump -d`)

**Not verified**

Only CH32V003 was tested on hardware. The other series (CH32VM00X / X035 / V10x / V20x / V30x / L10x) go through the same code path but were not tested on hardware.

**Verification sketch**

The same checks can be reproduced with a single jumper wire.

```cpp
/*
  HardwareSerial interrupt driven reception - verification sketch

  Wire the U(S)ART TX and RX pins together (PD5 and PD6 on CH32V003) and
  run this sketch. No USB serial adapter is needed: the port is busy with
  the loopback, so the result is reported on the LED.

  Note: this variant does not define LED_BUILTIN, so the pin is set below.

  What you should see

    all checks pass  ->  one short blink, repeating forever
    a check fails    ->  three long blinks, then the check number as
                         short blinks, repeating forever (the sketch stops)

  Check numbers

    2  available() is not 0 right after begin()
    3  bytes were lost while the sketch never called read()
    4  peek() did not return the first byte, or peek() != read()
    5  wrong read order, or the buffer did not go empty
    6  end() -> begin() did not restart reception
    7  the repeated 26 byte loopback comparison failed
*/

const int LED = PC0;          // no LED_BUILTIN on this variant

const char MSG[] = "== UART TEST 0123456789 ==";
const int  MSGLEN = 26;

static void shortBlink(int n)
{
  for (int k = 0; k < n; k++) {
    digitalWrite(LED, HIGH);
    for (volatile unsigned long i = 0; i < 250000UL; i++) { }
    digitalWrite(LED, LOW);
    for (volatile unsigned long i = 0; i < 250000UL; i++) { }
  }
}

static void longBlink(int n)
{
  for (int k = 0; k < n; k++) {
    digitalWrite(LED, HIGH);
    for (volatile unsigned long i = 0; i < 1500000UL; i++) { }
    digitalWrite(LED, LOW);
    for (volatile unsigned long i = 0; i < 700000UL; i++) { }
  }
}

static void pause(void)
{
  for (volatile unsigned long i = 0; i < 8000000UL; i++) { }
}

static void settle(void)
{
  for (volatile unsigned long i = 0; i < 200000UL; i++) { }
}

static void fail(int check)
{
  for (;;) {
    longBlink(3);
    pause();
    shortBlink(check);
    pause();
    pause();
  }
}

void setup()
{
  pinMode(LED, OUTPUT);
  Serial.begin(115200);
  settle();

  /* 2: nothing received yet */
  if (Serial.available() != 0) fail(2);

  /* 3: the bytes come back while write() is polling, read() is never
        called in between, so they can only survive through the interrupt */
  Serial.print("HELLO");
  settle();
  if (Serial.available() != 5) fail(3);

  /* 4: peek() does not consume */
  if (Serial.peek() != 'H') fail(4);
  if (Serial.read() != 'H') fail(4);

  /* 5: the rest comes out in order and the buffer goes empty */
  if (Serial.read() != 'E')    fail(5);
  if (Serial.read() != 'L')    fail(5);
  if (Serial.read() != 'L')    fail(5);
  if (Serial.read() != 'O')    fail(5);
  if (Serial.available() != 0) fail(5);
  if (Serial.read() != -1)     fail(5);

  /* 6: reception restarts after end() */
  Serial.end();
  Serial.begin(115200);
  settle();
  Serial.print("Z");
  settle();
  if (Serial.available() != 1) fail(6);
  if (Serial.read() != 'Z')    fail(6);
}

void loop()
{
  while (Serial.read() != -1) { }

  Serial.print(MSG);

  unsigned long guard = 0;
  while ((Serial.available() < MSGLEN) && (guard < 500000UL)) {
    guard++;
  }

  /* 7: every byte of the 26 byte string must come back unchanged, and it
        has to keep working round after round, not just once */
  for (int i = 0; i < MSGLEN; i++) {
    if (Serial.read() != (int)(unsigned char)MSG[i]) fail(7);
  }

  shortBlink(1);
  pause();
}
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
